### PR TITLE
Fix duplicate APRS-IS connections in clustered deployments

### DIFF
--- a/lib/aprsme/application.ex
+++ b/lib/aprsme/application.ex
@@ -139,8 +139,10 @@ defmodule Aprsme.Application do
 
   defp maybe_add_aprs_connection(children, _env) do
     disable_connection = Application.get_env(:aprsme, :disable_aprs_connection, false)
+    cluster_enabled = Application.get_env(:aprsme, :cluster_enabled, false)
 
-    if disable_connection do
+    # Don't add AprsIsConnection if clustering is enabled or connection is disabled
+    if disable_connection or cluster_enabled do
       children
     else
       children ++ [Aprsme.AprsIsConnection]


### PR DESCRIPTION
## Summary
- Fixed duplicate APRS-IS connections occurring in Kubernetes clustered deployments
- Added cluster-aware logic to prevent both `AprsIsConnection` and cluster-managed `Is` connection from starting simultaneously
- When clustering is enabled, only the cluster's `ConnectionManager` handles APRS-IS connections via leader election

## Problem
The application was creating duplicate APRS-IS connections because:
1. `AprsIsConnection` was always started regardless of clustering configuration
2. Cluster's `ConnectionManager` also started `IsSupervisor` (which manages `Aprsme.Is`)
3. Both modules connected to APRS-IS with the same username, causing server disconnections

## Solution
Modified `maybe_add_aprs_connection/2` in `lib/aprsme/application.ex` to:
- Check if clustering is enabled via `Application.get_env(:aprsme, :cluster_enabled, false)`
- Skip adding `AprsIsConnection` when clustering is enabled
- Allow cluster's leader election to manage all APRS-IS connections

## Test plan
- [x] Verify non-clustered deployments continue working (local development)
- [ ] Deploy to Kubernetes cluster and confirm only one APRS-IS connection
- [ ] Verify leader failover works correctly
- [ ] Check aprsc server logs for absence of duplicate connection messages

🤖 Generated with [Claude Code](https://claude.ai/code)