### PR TITLE
Fix MicE struct compilation errors

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
- Fixes compilation errors for `Aprs.Types.MicE` struct by enabling recursive submodule checkout in Claude workflow
- The MicE struct is defined in the `vendor/aprs` git submodule which wasn't being pulled during CI
- Updates `.github/workflows/claude.yml` to include `submodules: recursive` in the checkout step

## Test plan
- [x] Initialize submodules locally with `git submodule update --init --recursive`
- [x] Verify MicE struct is available at `vendor/aprs/lib/aprs/types/mic_e.ex`
- [x] Run `mix compile --warnings-as-errors` and confirm it passes without errors
- [x] Ensure Claude workflow will now have access to submodule dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)