### PR TITLE
Add real-time last update display to map sidebar

### DIFF
--- a/lib/aprsme_web/live/map_live/index.ex
+++ b/lib/aprsme_web/live/map_live/index.ex
@@ -199,7 +199,9 @@ defmodule AprsmeWeb.MapLive.Index do
       # Overlay controls
       overlay_callsign: "",
       # Slideover state - will be set based on screen size
-      slideover_open: true
+      slideover_open: true,
+      # Track when last update occurred for display
+      last_update_at: DateTime.utc_now()
     )
   end
 
@@ -1295,6 +1297,27 @@ defmodule AprsmeWeb.MapLive.Index do
           />
         </div>
         
+    <!-- Last Update -->
+        <div class="pt-4 border-t border-slate-200 space-y-3">
+          <div class="flex items-center space-x-2 text-sm text-slate-600">
+            <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            <span class="font-medium">{gettext("Last Update")}</span>
+          </div>
+          <div class="text-xs text-slate-500">
+            <div class="font-mono">{time_ago_in_words(@last_update_at)}</div>
+            <div class="font-mono text-slate-400">
+              {Calendar.strftime(@last_update_at, "%Y-%m-%d %H:%M UTC")}
+            </div>
+          </div>
+        </div>
+        
     <!-- Deployment Information -->
         <div class="pt-4 border-t border-slate-200 space-y-3">
           <div class="flex items-center space-x-2 text-sm text-slate-600">
@@ -1618,6 +1641,7 @@ defmodule AprsmeWeb.MapLive.Index do
       socket
       |> assign(map_bounds: map_bounds, packet_state: updated_packet_state)
       |> assign(needs_initial_historical_load: false)
+      |> assign(last_update_at: DateTime.utc_now())
 
     # Load historical packets for the new bounds (now socket.assigns.map_bounds is correct)
     Logger.debug("Starting progressive historical loading for new bounds")

--- a/lib/aprsme_web/live/map_live/index.ex
+++ b/lib/aprsme_web/live/map_live/index.ex
@@ -200,7 +200,8 @@ defmodule AprsmeWeb.MapLive.Index do
       overlay_callsign: "",
       # Slideover state - will be set based on screen size
       slideover_open: true,
-      # Track when last update occurred for display
+      # Track when last update occurred for real-time display in map sidebar
+      # Updated when packets are processed or map bounds change
       last_update_at: DateTime.utc_now()
     )
   end
@@ -1311,10 +1312,14 @@ defmodule AprsmeWeb.MapLive.Index do
             <span class="font-medium">{gettext("Last Update")}</span>
           </div>
           <div class="text-xs text-slate-500">
-            <div class="font-mono">{time_ago_in_words(@last_update_at)}</div>
-            <div class="font-mono text-slate-400">
-              {Calendar.strftime(@last_update_at, "%Y-%m-%d %H:%M UTC")}
-            </div>
+            <%= if @last_update_at do %>
+              <div class="font-mono">{time_ago_in_words(@last_update_at)}</div>
+              <div class="font-mono text-slate-400">
+                {Calendar.strftime(@last_update_at, "%Y-%m-%d %H:%M UTC")}
+              </div>
+            <% else %>
+              <div class="font-mono text-slate-500">No updates yet</div>
+            <% end %>
           </div>
         </div>
         
@@ -1641,6 +1646,7 @@ defmodule AprsmeWeb.MapLive.Index do
       socket
       |> assign(map_bounds: map_bounds, packet_state: updated_packet_state)
       |> assign(needs_initial_historical_load: false)
+      # Update last update timestamp when map bounds change - this triggers data refresh
       |> assign(last_update_at: DateTime.utc_now())
 
     # Load historical packets for the new bounds (now socket.assigns.map_bounds is correct)

--- a/lib/aprsme_web/live/map_live/packet_processor.ex
+++ b/lib/aprsme_web/live/map_live/packet_processor.ex
@@ -39,7 +39,8 @@ defmodule AprsmeWeb.MapLive.PacketProcessor do
     # Handle packet visibility logic
     socket = handle_packet_visibility(packet, lat, lon, callsign_key, socket)
     
-    # Update last update timestamp for display purposes
+    # Update last update timestamp for real-time display in map sidebar
+    # This timestamp is shown to users to indicate when data was last refreshed
     socket = assign(socket, :last_update_at, DateTime.utc_now())
     
     {:noreply, socket}

--- a/lib/aprsme_web/live/map_live/packet_processor.ex
+++ b/lib/aprsme_web/live/map_live/packet_processor.ex
@@ -38,6 +38,10 @@ defmodule AprsmeWeb.MapLive.PacketProcessor do
 
     # Handle packet visibility logic
     socket = handle_packet_visibility(packet, lat, lon, callsign_key, socket)
+    
+    # Update last update timestamp for display purposes
+    socket = assign(socket, :last_update_at, DateTime.utc_now())
+    
     {:noreply, socket}
   end
 


### PR DESCRIPTION
## Summary
Add a "Last Update" section to the map sidebar that displays when data was last refreshed in real-time.

## Changes
- **Socket State**: Added `last_update_at` timestamp to LiveView socket assigns
- **Packet Processing**: Update timestamp whenever packets are processed in `PacketProcessor.process_packet_for_display/2`
- **Bounds Updates**: Update timestamp when map bounds change in `process_bounds_update/2` 
- **UI Display**: Added "Last Update" section below navigation with:
  - Refresh icon matching existing deployment section style
  - Relative time display ("less than a minute ago")
  - Exact UTC timestamp ("2025-07-25 19:04 UTC")
  - Proper internationalization with gettext

## Features
- **Real-time Updates**: Automatically updates via Phoenix LiveView reactivity
- **Consistent Styling**: Matches existing sidebar sections with proper spacing
- **Accessibility**: Uses semantic markup and existing icon patterns
- **Performance**: Minimal overhead, only updates timestamp on actual data changes

## Test plan
- [ ] Verify "Last Update" section appears below navigation in map sidebar
- [ ] Confirm relative time updates when new APRS packets arrive
- [ ] Check exact timestamp matches actual update times  
- [ ] Ensure styling is consistent with existing sidebar sections
- [ ] Test on both desktop and mobile layouts

🤖 Generated with [Claude Code](https://claude.ai/code)