### PR TITLE
Fix packet spidering to only include most recent markers with icons

### DIFF
--- a/assets/js/map.ts
+++ b/assets/js/map.ts
@@ -502,8 +502,10 @@ let MapAPRSMap = {
         if (self.oms) {
           // Clear and re-add all markers to OMS on zoom change
           self.oms.clearMarkers();
-          self.markers.forEach((marker) => {
-            if (marker && !marker._isHistorical && !marker._isClusterMarker) {
+          self.markers.forEach((marker, id) => {
+            const markerState = self.markerStates.get(String(id));
+            // Only add most recent markers (those with icons) to OMS for spidering
+            if (marker && !marker._isClusterMarker && markerState && markerState.is_most_recent_for_callsign) {
               self.oms.addMarker(marker);
             }
           });
@@ -1547,8 +1549,8 @@ let MapAPRSMap = {
       marker.openPopup();
     }
 
-    // Add to OMS for overlapping marker handling (only non-historical markers)
-    if (self.oms && marker && self.map && !marker._isClusterMarker && !(marker as APRSMarker)._isHistorical) {
+    // Add to OMS for overlapping marker handling (only most recent packets with icons)
+    if (self.oms && marker && self.map && !marker._isClusterMarker && data.is_most_recent_for_callsign) {
       self.oms.addMarker(marker);
     }
   },


### PR DESCRIPTION
## Summary
Fixed the OverlappingMarkerSpiderfier (OMS) logic to properly filter markers for spidering functionality. The issue was that spidering stopped working after modifications intended to only spider recent packets with icons.

## Problem
The OMS was incorrectly configured to exclude historical markers using `\!_isHistorical`, but wasn't properly checking for `is_most_recent_for_callsign` which determines whether a marker shows an APRS icon or just a dot.

## Changes
- **Fixed addMarker()**: Now checks `data.is_most_recent_for_callsign` to only add markers with icons to OMS
- **Fixed zoom handler**: Now checks `markerState.is_most_recent_for_callsign` when re-adding markers after zoom changes
- Updated comments to clarify the intent: "only most recent packets with icons"

## Behavior
- ✅ **Most recent markers** (with APRS icons and callsign labels) participate in spidering
- ✅ **Historical markers** (red dots) are excluded from spidering
- ✅ When multiple stations are close together, clicking will spider out the current position markers
- ✅ Maintains proper user experience with interactive elements

## Test plan
- [x] Code compiles successfully with `mix compile --warnings-as-errors`
- [x] Assets build successfully with `mix assets.deploy`
- [x] Application starts and connects to APRS-IS
- [ ] Manual testing: Navigate to map with overlapping recent markers and verify spidering works
- [ ] Manual testing: Verify historical dots don't participate in spidering

🤖 Generated with [Claude Code](https://claude.ai/code)